### PR TITLE
JSON escape in jinjava.jsonc

### DIFF
--- a/jinjava.jsonc
+++ b/jinjava.jsonc
@@ -956,7 +956,7 @@
 	"Filter Bool": {
 		"prefix": "filter Bool",
 		"body": [
-			"{%- if "true"|bool == true -%}",
+			"{%- if \"true\"|bool == true -%}",
 				"\thello world",
 			"{%- endif -%}"
 		],


### PR DESCRIPTION
adding a backslash (  \  ). This update was committed to the repository to correct an escape character issue or to ensure proper formatting within the JSON structure.